### PR TITLE
Include precision, scale, radix

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ var informationSchemaFields = module.exports.informationSchemaFields = [
 	'numeric_precision',
 	'numeric_scale',
 	'numeric_precision_radix',
-	'datetime_precision'
+	'datetime_precision',
+	'interval_type',
+	'interval_precision'
 ]
 
 var datetimePrecisionTypes = [
@@ -126,6 +128,9 @@ function createMetadataObject(resultSet) {
 			s.precision_radix = row.numeric_precision_radix
 		} else if (datetimePrecisionTypes.indexOf(s.type) >= 0) {
 			s.precision = row.datetime_precision
+		} else if (s.type === 'interval') {
+			s.precision = row.interval_precision
+			s.interval_type = row.interval_type
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,18 @@ var informationSchemaFields = module.exports.informationSchemaFields = [
 	'table_schema',
 	'table_catalog',
 	'is_nullable',
-	'numeric_precision'
+	'numeric_precision',
+	'numeric_scale',
+	'numeric_precision_radix',
+	'datetime_precision'
+]
+
+var datetimePrecisionTypes = [
+	'timestamp',
+	'timestamptz',
+	'date',
+	'time',
+	'timetz'
 ]
 
 function pgMetadata(connection, options, callback) {
@@ -102,10 +113,19 @@ function createMetadataObject(resultSet) {
 			schema[row.table_name] = table = {}
 		}
 
-		table[key] = {
+		var s = table[key] = {
 			type: row.udt_name,
-			length: row.character_maximum_length ?  row.character_maximum_length : row.numeric_precision,
 			required: row.is_nullable ? true : false
+		}
+
+		if (s.type.indexOf('char')>=0 || s.type.indexOf('text')>=0) {
+			s.length = row.character_maximum_length
+		} else if (row.numeric_precision_radix != null) {
+			s.precision = row.numeric_precision
+			s.scale = row.numeric_scale
+			s.precision_radix = row.numeric_precision_radix
+		} else if (datetimePrecisionTypes.indexOf(s.type) >= 0) {
+			s.precision = row.datetime_precision
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "pg-escape": "0.0.2"
   },
   "devDependencies": {
+    "mocha": "~2.2.5",
     "should": "^6.0.3"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -7,14 +7,143 @@ describe('pg-metadata', function () {
 
 	var resultSet = [
 		// two columns for table "atable" in schema "aschema" in db "adb"
-		{ character_maximum_length: 244, column_name: 'a', udt_name: 'varchar', table_name: 'atable', table_schema: 'aschema', table_catalog: 'adb', is_nullable: true },
-		{ character_maximum_length: 244, column_name: 'b', udt_name: 'varchar', table_name: 'atable', table_schema: 'aschema', table_catalog: 'adb' },
+		{
+			character_maximum_length: 244,
+			column_name: 'a',
+			udt_name: 'varchar',
+			table_name: 'atable',
+			table_schema: 'aschema',
+			table_catalog: 'adb',
+			is_nullable: true,
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: null
+		},
+		{ 
+			character_maximum_length: 244,
+			column_name: 'b',
+			udt_name: 'varchar',
+			table_name: 'atable',
+			table_schema: 'aschema',
+			table_catalog: 'adb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: null },
 
 		// one column for table "btable" in schema "aschama" in db "adb"
-		{ character_maximum_length: 244, column_name: 'a', udt_name: 'varchar', table_name: 'btable', table_schema: 'aschema', table_catalog: 'adb' },
+		{ character_maximum_length: 244,
+			column_name: 'a',
+			udt_name: 'varchar',
+			table_name: 'btable',
+			table_schema: 'aschema',
+			table_catalog: 'adb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: null },
 
 		// one column for table "btable" in schema "bschema" in db "bdb"
-		{ character_maximum_length: 244, column_name: 'a', udt_name: 'varchar', table_name: 'btable', table_schema: 'bschema', table_catalog: 'bdb' }
+		{ character_maximum_length: 244,
+			column_name: 'a',
+			udt_name: 'varchar',
+			table_name: 'btable',
+			table_schema: 'bschema',
+			table_catalog: 'bdb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: null },
+
+		// two numeric columns for table "ctable" in schema "cschema" in db "cdb"
+		{ character_maximum_length: null,
+			column_name: 'a',
+			udt_name: 'float4',
+			table_name: 'ctable',
+			table_schema: 'cschema',
+			table_catalog: 'cdb',
+			numeric_precision: 24,
+			numeric_scale: null,
+			numeric_precision_radix: 2,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: null },
+
+		{ character_maximum_length: null,
+			column_name: 'b',
+			udt_name: 'numeric',
+			table_name: 'ctable',
+			table_schema: 'cschema',
+			table_catalog: 'cdb',
+			numeric_precision: 12,
+			numeric_scale: 2,
+			numeric_precision_radix: 10,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: null },
+
+		// two interval columns for table "dtable" in schema "dschema" in db "ddb"
+		{ character_maximum_length: null,
+			column_name: 'a',
+			udt_name: 'interval',
+			table_name: 'dtable',
+			table_schema: 'dschema',
+			table_catalog: 'ddb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: null,
+			interval_type: 'YEAR',
+			interval_precision: null },
+
+		{ character_maximum_length: null,
+			column_name: 'b',
+			udt_name: 'interval',
+			table_name: 'dtable',
+			table_schema: 'dschema',
+			table_catalog: 'ddb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: null,
+			interval_type: null,
+			interval_precision: 2 },
+
+		// two datetime columns for table "etable" in schema "eschema" in db "edb"
+		{ character_maximum_length: null,
+			column_name: 'a',
+			udt_name: 'time',
+			table_name: 'etable',
+			table_schema: 'eschema',
+			table_catalog: 'edb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: 6,
+			interval_type: null,
+			interval_precision: null },
+
+		{ character_maximum_length: null,
+			column_name: 'b',
+			udt_name: 'timestamptz',
+			table_name: 'etable',
+			table_schema: 'eschema',
+			table_catalog: 'edb',
+			numeric_precision: null,
+			numeric_scale: null,
+			numeric_precision_radix: null,
+			datetime_precision: 4,
+			interval_type: null,
+			interval_precision: null },
 	]
 
 	describe('creates a query', function () {
@@ -56,6 +185,9 @@ describe('pg-metadata', function () {
 			
 			actual.should.have.property('adb')
 			actual.should.have.property('bdb')
+			actual.should.have.property('cdb')
+			actual.should.have.property('ddb')
+			actual.should.have.property('edb')
 		})
 
 		it('schemas in a database', function () {
@@ -63,6 +195,9 @@ describe('pg-metadata', function () {
 			
 			actual.adb.should.have.property('aschema')
 			actual.bdb.should.have.property('bschema')
+			actual.cdb.should.have.property('cschema')
+			actual.ddb.should.have.property('dschema')
+			actual.edb.should.have.property('eschema')
 		})
 
 		it('tables in each schema', function () {
@@ -87,6 +222,8 @@ describe('pg-metadata', function () {
 			
 			actual.adb.aschema.atable.a.should.have.property('type', 'varchar')
 			actual.adb.aschema.atable.a.should.have.property('length', 244)
+			actual.adb.aschema.atable.a.should.not.have.property('scale')
+			actual.adb.aschema.atable.a.should.not.have.property('precision_radix')
 			actual.adb.aschema.atable.a.should.have.property('required', true)
 
 			actual.adb.aschema.atable.b.should.have.property('type', 'varchar')
@@ -95,6 +232,33 @@ describe('pg-metadata', function () {
 
 			actual.bdb.bschema.btable.a.should.have.property('type', 'varchar')
 			actual.bdb.bschema.btable.a.should.have.property('length', 244)
+
+			actual.cdb.should.be.eql({
+				cschema: {
+					ctable: {
+						a: { type: 'float4', required: false, precision: 24, scale: null, precision_radix: 2 },
+						b: { type: 'numeric', required: false, precision: 12, scale: 2, precision_radix: 10 }
+					}
+				}
+			})
+
+			actual.ddb.should.be.eql({
+				dschema: {
+					dtable: {
+						a: { type: 'interval', required: false, 'interval_type': 'YEAR', precision: null },
+						b: { type: 'interval', required: false, 'interval_type': null, precision: 2 }
+					}
+				}
+			})
+
+			actual.edb.should.be.eql({
+				eschema: {
+					etable: {
+						a: { type: 'time', required: false, precision: 6 },
+						b: { type: 'timestamptz', precision: 4, required: false }
+					}
+				}
+			})
 		})
 	})
 


### PR DESCRIPTION
This PR adds some metadata to numeric, datetime and interval types:

``` js
real: {
  type: 'float4',
  required: true,
  precision: 24,
  scale: null,
  precision_radix: 2
},

time_tz: {
  type: 'timetz',
  required: true,
  precision: 6
},

interval_year: {
  type: 'interval',
  interval_type: 'YEAR',
  required: true,
  precision: null
}
```

And `length` is only added to the char/text types, instead of all types.
